### PR TITLE
91334/hotfix-lucide-icon

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,11 +7,11 @@ import "custom/modal";
 import "custom/admin_user_courses";
 import { createIcons, icons } from "lucide";
 import "./custom/take_test";
-import "jquery"
-import "@rails/request.js"
+import "jquery";
+import "@rails/request.js";
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("turbo:load", () => {
   createIcons({ icons });
 });
-import "trix"
-import "@rails/actiontext"
+import "trix";
+import "@rails/actiontext";

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_13_102207) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["course_id"], name: "index_admin_course_managers_on_course_id"
-    t.index ["user_id", "course_id"], name: "index_admin_course_managers_on_user_id_and_course_id", unique: true
     t.index ["user_id"], name: "index_admin_course_managers_on_user_id"
   end
 
@@ -78,7 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_13_102207) do
     t.bigint "created_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "duration"
+    t.integer "duration", default: 0, null: false
     t.index ["created_by_id"], name: "index_courses_on_created_by_id"
     t.index ["title"], name: "index_courses_on_title", unique: true
   end
@@ -170,10 +169,10 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_13_102207) do
     t.integer "gender"
     t.integer "role", default: 0, null: false
     t.string "remember_digest"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end


### PR DESCRIPTION
## Checklist tự review pull trước khi ready nhờ trainer review
- [x] Kiểm tra mỗi pull request 1 commit, nếu nhiều commit thì hãy gộp commit thành 1 rồi đẩy lại lên git
- [x] Trong các file của rails (đuôi .erb, .rb, .yml): sử dụng nháy " thay vì nháy '
- [x] Trong file javascript: sử dụng nháy ' thay vì "
- [x] Sử dụng thụt lề 2 space (setting lại vscode /sublime text nếu chưa cài đặt)
- [x] Cuối mỗi file kiểm tra có end line (khi đẩy lên git xem file change k bị lỗi tròn đỏ ở cuối file)
- [x] Mỗi dòng nếu quá dài, cần xuống dòng (maximum: 80 kí tự mỗi dòng)
- [x] Xóa các file được tự động sinh ra khi dùng các câu lệnh rails generate ... tạo ra nhưng k dùng đến, không có dòng code nào được viết trong đó (hay gặp nhất là các file helper)
- [x] Khi tạo mảng, nên tích cực sử dụng %w( ), %i() . Thay vì STATES = ['draft', 'open', 'closed'] có thể dùng STATES = %w(draft open closed)
- [x] Xem các lỗi hay gặp khi triển khai Rails tutorial tại https://docs.google.com/document/d/104Csp4-vamVos5DEbi372nLBEfmqhj7h1ENYO8ebjCo/edit
- [x] Tham khảo coding convention https://github.com/framgia/coding-standards/blob/master/vn/README.md

## Related Tickets
- [ticket redmine](https://edu-redmine.sun-asterisk.vn/issues/91334)

## WHAT (optional)
- Fix lỗi không hiển thị icon trong lần đầu tiên

## HOW
- I edit js file, inject not_vary_normal items in calculate function.

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)

<img width="1889" height="794" alt="image" src="https://github.com/user-attachments/assets/b2caf03f-0561-44a4-99f7-c896c9d844d5" />

## Notes (Kiến thức tìm hiểu thêm)
